### PR TITLE
Refresh recruiter-focused README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,38 @@
-# Flask Web App Starter
+# Eric Nielson — Product Leadership Portfolio
 
-A Flask starter template as per [these docs](https://flask.palletsprojects.com/en/3.0.x/quickstart/#a-minimal-application).
+This README is designed as a quick, high-signal briefing for talent partners assessing my fit for senior product leadership roles. You will find results, case studies, and proof points that map directly to the questions most teams ask during executive screens.
 
-## Getting Started
+## Snapshot
+- **Enterprise impact:** Built and scaled products at Komodo Health, Amazon, and Disney that unlocked over $500M in new revenue, efficiency, and retention.
+- **Operational range:** Air Force Major and adjunct MBA professor with a track record leading cross-functional teams through ambiguity, transformation, and high-stakes launches.
+- **Builder mindset:** Ship AI-enabled workflows, experimentation frameworks, and data-rich storytelling that connect strategy to measurable outcomes.
 
-Previews should run automatically when starting a workspace.
+> 🧭 Want the full context? Explore the live portfolio experience at [idx-test2-3592241-4xeemoth6q-ul.a.run.app](https://idx-test2-3592241-4xeemoth6q-ul.a.run.app/).
+
+## What to Review First
+| Focus Area | Link | Why It Resonates |
+| --- | --- | --- |
+| Strategic Platform Building | [MapLab](templates/maplab.html) | Illustrates how I packaged Komodo Health’s data assets into repeatable workflows that scaled customer adoption. |
+| Voice of the Customer | [VOC Program](templates/voc.html) | Demonstrates a closed-loop signal pipeline prioritizing 50+ roadmap enhancements across GTM, product, and support. |
+| High-Stakes GTM | [Amazon Prime Events](templates/Peas.html) | Details the experimentation, automation, and crisis playbooks that protected Prime Day revenue globally. |
+| Applied AI & Forecasting | [CFB Prediction Model](templates/cfbpredictions.html) & [Feature ROI Forecasting](templates/forecasting.html) | Highlights model design, explainability, and executive storytelling for investment decisions. |
+| Coaching & Scale | [MBA Teaching Assistant](templates/teaching_assistant.html) & [Teaching Feedback](templates/teaching_feedback.html) | Shows how I build psychological safety and feedback loops to up-level talent. |
+
+## What I Bring to a Product Org
+- **Customer-backed strategy:** Blend qualitative and quantitative inputs into roadmaps that stay aligned to revenue, retention, and regulatory goals.
+- **Hands-on analytics:** Comfortable querying data, building prototypes in Python/Flask, orchestrating LLM agents, and visualizing impact for executives.
+- **Systems thinking:** Design operating cadences, OKRs, and communication patterns that let teams move quickly without losing control of risk.
+- **Culture builder:** Apply lessons from military leadership and MBA instruction to develop inclusive, high-trust environments.
+
+## Repository Guide
+- `app.py` — Flask entry point defining routes for each portfolio story.
+- `templates/` — HTML templates powering the case studies and demos.
+- `static/` — Design system, imagery, and front-end assets.
+- `models/` — Forecasting and modeling artifacts referenced in the demos.
+
+## Connect
+- **Email:** ericjnielson2@gmail.com
+- **LinkedIn:** [linkedin.com/in/ericjnielson](https://www.linkedin.com/in/ericjnielson/)
+- **Location:** New York, NY (open to in-person, hybrid, or remote roles)
+
+If you only have a few minutes, start with the table above—each link maps to a tangible outcome with metrics, artifacts, and leadership narratives you can reference during stakeholder debriefs.


### PR DESCRIPTION
## Summary
- rewrite the README as a recruiter-oriented briefing with concise impact highlights and navigation guidance
- update contact details to point to the preferred email while keeping location and LinkedIn current

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbd8f91548325bd831cbc33ca8b81