### PR TITLE
Use the homepage navbar on every page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -3897,3 +3897,15 @@ label, .form-group label { color: var(--ds-text); }
   .cc-hero { padding: 52px 20px 44px; }
   .cc-chip { flex: 1 1 45%; min-width: 140px; }
 }
+
+/* ============================================================
+   Consistent navbar across all pages: same look as the homepage
+   nav (logo + section links + theme toggle). The body.home rules
+   above still win on the homepage, where scroll-spy adds .active.
+   ============================================================ */
+.nav-links a {
+  color: var(--ds-text-muted); font-weight: 600; text-decoration: none;
+  position: relative; padding: 4px 2px; transition: color .2s ease;
+}
+.nav-links a:hover { color: var(--ds-text); text-decoration: none; }
+.nav-links ~ .theme-toggle { margin-left: 18px; }

--- a/templates/Liveconnect.html
+++ b/templates/Liveconnect.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/Peas.html
+++ b/templates/Peas.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/aperture.html
+++ b/templates/aperture.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/cfbpredictions.html
+++ b/templates/cfbpredictions.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/forecasting.html
+++ b/templates/forecasting.html
@@ -19,7 +19,14 @@
 <body class="bg-gray-100">
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/maplab.html
+++ b/templates/maplab.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/mba.html
+++ b/templates/mba.html
@@ -19,9 +19,15 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
-
         </div>
     </nav>
 

--- a/templates/reinforcement_learning.html
+++ b/templates/reinforcement_learning.html
@@ -20,7 +20,14 @@
     <!-- Main Navigation -->
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/teaching_assistant.html
+++ b/templates/teaching_assistant.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/teaching_feedback.html
+++ b/templates/teaching_feedback.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>

--- a/templates/voc.html
+++ b/templates/voc.html
@@ -19,7 +19,14 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="/" class="nav-logo">Home</a>
+            <a href="/" class="nav-logo">Eric Nielson</a>
+            <div class="nav-links">
+                <a href="/#highlights">Highlights</a>
+                <a href="/#work">Work</a>
+                <a href="/#projects">Projects</a>
+                <a href="/#timeline">Timeline</a>
+                <a href="/#connect">Connect</a>
+            </div>
             <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false"><span class="theme-toggle__icon" aria-hidden="true">🌙</span></button>
         </div>
     </nav>


### PR DESCRIPTION
Makes the nav bar consistent across the whole site.

## Changes
- Every page (work examples, personal projects, MBA, teaching feedback) now uses the same navbar as the homepage: "Eric Nielson" logo, section links (Highlights, Work, Projects, Timeline, Connect), and the theme toggle
- Section links point to homepage anchors (`/#work`, etc.) so they navigate back correctly from subpages
- Adds site-wide `.nav-links` styling in `styles.css` — the previous rules were scoped to `body.home`, so on other pages the links would have rendered white-on-white
- Verified in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMeTFmCqp1DJohXramZD1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMeTFmCqp1DJohXramZD1F)_